### PR TITLE
Introduce web3 fixture + Deployer readiness assertions

### DIFF
--- a/nkms_eth/actors.py
+++ b/nkms_eth/actors.py
@@ -151,7 +151,7 @@ class Miner(TokenActor):
     def collect_staking_reward(self) -> str:
         """Withdraw tokens rewarded for staking."""
 
-        token_amount_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent._deployer.MinerInfoField.VALUE.value,
+        token_amount_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent.MinerInfo.VALUE.value,
                                                                   self.address,
                                                                   0).encode('latin-1')
 
@@ -181,7 +181,7 @@ class Miner(TokenActor):
             raise self.StakingError('Locktime must be at least {}'.format(min_stake_time))
 
         if entire_balance is True:
-            balance_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent._deployer.MinerInfoField.VALUE.value,
+            balance_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent.MinerInfo.VALUE.value,
                                                                  self.address,
                                                                  0).encode('latin-1')
 
@@ -212,15 +212,15 @@ class Miner(TokenActor):
     def fetch_data(self) -> tuple:
         """Retrieve all asosciated contract data for this miner."""
 
-        count_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent._deployer.MinerInfoField.MINER_IDS_LENGTH.value,
-                                                     self.address,
-                                                     0).encode('latin-1')  # TODO change when v4 of web3.py is released
+        count_bytes = self.miner_agent.read().getMinerInfo(self.miner_agent.MinerInfo.MINER_IDS_LENGTH.value,
+                                                           self.address,
+                                                           0).encode('latin-1')  # TODO change when v4 of web3.py is released
 
         count = self.blockchain._chain.web3.toInt(count_bytes)
 
         miner_ids = list()
         for index in range(count):
-            miner_id = self.miner_agent.read().getMinerInfo(self.miner_agent._deployer.MinerInfoField.MINER_ID.value,
+            miner_id = self.miner_agent.read().getMinerInfo(self.miner_agent.MinerInfo.MINER_ID.value,
                                                             self.address,
                                                             index)
             encoded_miner_id = miner_id.encode('latin-1')

--- a/nkms_eth/agents.py
+++ b/nkms_eth/agents.py
@@ -1,7 +1,11 @@
 import random
 from abc import ABC
+from enum import Enum
+
 from functools import partial
 from typing import Set, Generator, List
+
+from web3.contract import Contract
 
 from nkms_eth.deployers import MinerEscrowDeployer, NuCypherKMSTokenDeployer, PolicyManagerDeployer, ContractDeployer
 
@@ -19,7 +23,7 @@ class EthereumContractAgent(ABC):
     def __init__(self, blockchain, *args, **kwargs):
 
         self.blockchain = blockchain
-        self._contract = self.blockchain._chain.provider.get_contract(self._principal_contract_name)
+        # self._contract = Contract(address)
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -91,7 +95,7 @@ class MinerAgent(EthereumContractAgent):
     class NotEnoughUrsulas(Exception):
         pass
 
-    class MinerInfoField(Enum):
+    class MinerInfo(Enum):
         MINERS_LENGTH = 0
         MINER = 1
         VALUE = 2
@@ -130,7 +134,7 @@ class MinerAgent(EthereumContractAgent):
         """
 
         info_reader = partial(self.read().getMinerInfo,
-                              self.MinerInfoField.MINERS_LENGTH.value,
+                              self.MinerInfo.MINERS_LENGTH.value,
                               self._deployer._null_addr)
 
         count = info_reader(0).encode('latin-1')

--- a/nkms_eth/blockchain.py
+++ b/nkms_eth/blockchain.py
@@ -25,7 +25,7 @@ class TheBlockchain(ABC):
     class IsAlreadyRunning(RuntimeError):
         pass
 
-    def __init__(self, populus_config: EthereumConfig=None):
+    def __init__(self, eth_config: EthereumConfig):
         """
         Configures a populus project and connects to blockchain.network.
         Transaction timeouts specified measured in seconds.
@@ -36,17 +36,12 @@ class TheBlockchain(ABC):
 
         # Singleton
         if TheBlockchain.__instance is not None:
-            message = '{} is already running. Use .get() to retrieve'.format(self._network)
+            message = '{} is already running on {}. Use .get() to retrieve'.format(self.__class__.__name__, self._network)
             raise TheBlockchain.IsAlreadyRunning(message)
         TheBlockchain.__instance = self
 
-        if populus_config is None:
-            populus_config = EthereumConfig()
-        self._populus_config = populus_config
-        self._project = populus_config.project
-
-        # Opens and preserves connection to a running populus blockchain
-        self._chain = self._project.get_chain(self._network).__enter__()
+        self._eth_config = eth_config
+        self._chain = eth_config.provider  # TODO
 
     @classmethod
     def get(cls):

--- a/nkms_eth/config.py
+++ b/nkms_eth/config.py
@@ -1,4 +1,7 @@
+import os
 from enum import Enum
+from pathlib import Path
+
 from os.path import dirname, join, abspath
 
 import appdirs
@@ -55,9 +58,11 @@ class NuCypherMinerConfig:
 
 class EthereumConfig:
     __python_project_name = 'nucypher-kms'
-    __default_solidity_dir = os.path.join()    # TODO
+    # __default_solidity_dir = os.path.join()    # TODO: NKMSConfig Classes
 
-    def __init__(self, registrar_path=None):
+    def __init__(self, provider, registrar_path=None):
+
+        self.provider = provider
 
         # This config is persistent and is created in user's .local directory
         if registrar_path is None:
@@ -67,7 +72,6 @@ class EthereumConfig:
         # Populus project config
         self._project_dir = join(dirname(abspath(nkms_eth.__file__)), 'project')
         self._populus_project = populus.Project(self._project_dir)
-
         self.project.config['chains.mainnetrpc.contracts.backends.JSONFile.settings.file_path'] = self._registrar_path
 
     @property

--- a/nkms_eth/deployers.py
+++ b/nkms_eth/deployers.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Dict
 
 from populus.contracts.contract import PopulusContract
+from web3.contract import Contract
 
 from nkms_eth.config import NuCypherMinerConfig, NuCypherTokenConfig
 from .blockchain import TheBlockchain
@@ -93,12 +94,14 @@ class ContractDeployer:
         if not available:
             raise self.ContractDeploymentError('Contract is not available')
 
-    def _wrap_government(self, dispatcher_contract: PopulusContract, target_contract: PopulusContract) -> PopulusContract:
+        return True
+
+    def _wrap_government(self, dispatcher_contract: Contract, target_contract: Contract) -> Contract:
 
         # Wrap the contract
         wrapped_contract = self.blockchain._chain.web3.eth.contract(target_contract.abi,
-                                                                           dispatcher_contract.address,
-                                                                           ContractFactoryClass=PopulusContract)
+                                                                    dispatcher_contract.address,
+                                                                    ContractFactoryClass=Contract)
         return wrapped_contract
 
     def arm(self, fail_on_abort=True) -> None:
@@ -112,8 +115,8 @@ class ContractDeployer:
         incorrectly types the arming_word.
 
         """
-
-        # self.check_ready_to_deploy(fail=True)
+        if self.__armed is True:
+            raise self.ContractDeploymentError('{} deployer is already armed.'.format(self._contract_name))
 
         # If the blockchain network is public, prompt the user
         if self.blockchain._network not in self.blockchain.test_chains:
@@ -154,7 +157,7 @@ class NuCypherKMSTokenDeployer(ContractDeployer, NuCypherTokenConfig):
 
     def __init__(self, blockchain):
         super().__init__(blockchain=blockchain)
-        self._creator = self.blockchain._chain.web3.eth.accounts[0]
+        self._creator = self.blockchain._eth_config.provider.get_accounts()[0]    # TODO: make swappable
 
     def deploy(self) -> str:
         """
@@ -164,8 +167,8 @@ class NuCypherKMSTokenDeployer(ContractDeployer, NuCypherTokenConfig):
         The contract must be armed before it can be deployed.
         Deployment can only ever be executed exactly once!
         """
-
-        self.check_ready_to_deploy(fail=True)
+        is_ready, _disqualifications = self.check_ready_to_deploy(fail=True)
+        assert is_ready
 
         the_nucypher_token_contract, deployment_txhash = self.blockchain._chain.provider.deploy_contract(
             self._contract_name,
@@ -193,12 +196,14 @@ class DispatcherDeployer(ContractDeployer):
         super().__init__(blockchain=token_agent.blockchain)
 
     def deploy(self) -> str:
+
         dispatcher_contract, txhash = self.blockchain._chain.provider.deploy_contract(
             'Dispatcher', deploy_args=[self.target_contract.address],
             deploy_transaction={'from': self.token_agent.origin})
 
         self._contract = dispatcher_contract
         return txhash
+
 
 class MinerEscrowDeployer(ContractDeployer, NuCypherMinerConfig):
     """
@@ -225,11 +230,12 @@ class MinerEscrowDeployer(ContractDeployer, NuCypherMinerConfig):
             - Transfer reward tokens origin -> MinerEscrow contract
             - MinerEscrow contract initialization
 
-        Returns transaction hashes in a tuple.
+        Returns transaction hashes in a dict.
         """
 
         # Raise if not all-systems-go
-        self.check_ready_to_deploy(fail=True)
+        is_ready, _disqualifications = self.check_ready_to_deploy(fail=True)
+        assert is_ready
 
         # Build deployment arguments
         deploy_args = [self.token_agent.contract_address] + self.mining_coefficient    # config
@@ -285,21 +291,22 @@ class PolicyManagerDeployer(ContractDeployer):
 
     _contract_name = 'PolicyManager'
 
-    def __init__(self, miner_agent):
-        self.token_agent = miner_agent.token_agent
-        self.miner_agent = miner_agent
-        super().__init__(blockchain=self.token_agent.blockchain)
+    def __init__(self, miner_escrow_deployer):
+        self.token_deployer = miner_escrow_deployer.token_agent
+        self.miner_escrow_deployer = miner_escrow_deployer
+        super().__init__(blockchain=self.miner_escrow_deployer.blockchain)
 
     def deploy(self) -> Dict[str, str]:
-        self.check_ready_to_deploy(fail=True)
+        is_ready, _disqualifications = self.check_ready_to_deploy(fail=True)
+        assert is_ready
 
         # Creator deploys the policy manager
         the_policy_manager_contract, deploy_txhash = self.blockchain._chain.provider.deploy_contract(
             self._contract_name,
-            deploy_args=[self.miner_agent.contract_address],
-            deploy_transaction={'from': self.token_agent.origin})
+            deploy_args=[self.miner_escrow_deployer.contract_address],
+            deploy_transaction={'from': self.token_deployer.origin})
 
-        dispatcher_deployer = DispatcherDeployer(token_agent=self.token_agent, target_contract=the_policy_manager_contract)
+        dispatcher_deployer = DispatcherDeployer(token_agent=self.token_deployer, target_contract=the_policy_manager_contract)
         dispatcher_deployer.arm(fail_on_abort=True)
         dispatcher_deploy_txhash = dispatcher_deployer.deploy()
 
@@ -315,7 +322,7 @@ class PolicyManagerDeployer(ContractDeployer):
         the_policy_manager_contract = wrapped_policy_manager_contract
 
         # Configure the MinerEscrow by setting the PolicyManager
-        policy_setter_txhash = self.miner_agent.transact({'from': self.token_agent.origin}).\
+        policy_setter_txhash = self.miner_escrow_deployer.transact({'from': self.token_deployer.origin}).\
             setPolicyManager(the_policy_manager_contract.address)
 
         self.blockchain.wait_for_receipt(policy_setter_txhash)
@@ -338,13 +345,17 @@ class UserEscrowDeployer(ContractDeployer):
 
     _contract_name = 'UserEscrow'  # TODO
 
-    def __init__(self, miner_deployer, policy_deployer, *args, **kwargs):
-        self.miner_deployer = miner_deployer
+    def __init__(self, miner_escrow_deployer, policy_deployer):
+        self.miner_deployer = miner_escrow_deployer
         self.policy_deployer = policy_deployer
-        self.token_deployer = miner_deployer.token_deployer
-        super(*args, **kwargs).__init__(blockchain=miner_deployer.blockchain)
+
+        self.token_deployer = miner_escrow_deployer.token_deployer
+        super().__init__(blockchain=miner_escrow_deployer.blockchain)
 
     def deploy(self):
+        is_ready, _disqualifications = self.check_ready_to_deploy(fail=True)
+        assert is_ready
+
         deployment_args = [self.token_deployer.contract_address,
                            self.miner_deployer.contract_address,
                            self.policy_deployer.contract_address],
@@ -357,21 +368,3 @@ class UserEscrowDeployer(ContractDeployer):
 
         self._contract = the_user_escrow_contract
         return deploy_txhash
-
-
-class IssuerDeployer(ContractDeployer):
-
-    _contract_name = 'Issuer'
-
-    def __init__(self, miner_deployer, policy_deployer, *args, **kwargs):
-        self.miner_deployer = miner_deployer
-        self.policy_deployer = policy_deployer
-        self.token_deployer = miner_deployer.token_deployer
-        super(*args, **kwargs).__init__(blockchain=miner_deployer.blockchain)
-
-    def deploy(self):
-        # Creator deploys the issuer
-        issuer, _ = self.blockchain._chain.provider.get_or_deploy_contract(
-            'IssuerMock', deploy_args=[token.addrdebess, 1, 10 ** 46, 10 ** 7, 10 ** 7],
-            deploy_transaction={'from': creator})
-


### PR DESCRIPTION
- assert is_ready for EthereumContract Deployers
- Outlines pytest fixture with web3 test provider
- .arm() checks for prior arming
- Moves and renames MinerInfo Enum
- Absorb populus config -> EthereumConfig
- Fixes super usage